### PR TITLE
feat(cli): show help when no args are provided

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,11 @@ cli.help();
 cli.version(packageJson.version);
 
 try {
+  if (process.argv.slice(2).length === 0) {
+    cli.outputHelp();
+    process.exit(0);
+  }
+
   cli.parse();
 } catch (err) {
   // CAC throws on unknown options / bad usage. Exit code 2 = USAGE per plan.

--- a/tests/e2e/global-flags.test.ts
+++ b/tests/e2e/global-flags.test.ts
@@ -29,6 +29,17 @@ describe("e2e: global flags", () => {
     expect(output).toContain("doctor");
   });
 
+  it("no args exits 0 with command list", () => {
+    const result = runCli([]);
+    expect(result.exitCode).toBe(0);
+    const output = result.stdout + result.stderr;
+    expect(output).toContain("10x");
+    expect(output).toContain("auth");
+    expect(output).toContain("get");
+    expect(output).toContain("list");
+    expect(output).toContain("doctor");
+  });
+
   it("unknown option on a command exits 2 with usage error", () => {
     const result = runCli(["auth", "--nonexistent-flag"]);
     expect(result.exitCode).toBe(2);


### PR DESCRIPTION
Print the root help output and exit successfully when the CLI is invoked without flags or commands. Add e2e coverage so the no-args behavior stays aligned with --help.

before
```
> 10x
> 
```

after
```
> 10x
10x/1.6.0

Usage:
  $ 10x <command> [options]

Commands:
  auth           Authenticate with 10xDevs via magic link
  get <ref>      Fetch and apply a lesson pack
  list [module]  Browse available modules and lessons
  doctor         Diagnose auth, API, config, and tool directory state

For more info, run any command with the `--help` flag:
  $ 10x auth --help
  $ 10x get --help
  $ 10x list --help
  $ 10x doctor --help

Options:
  --json         Output as JSON (auto-detected when piped)
  --verbose      Show detailed output on stderr
  -h, --help     Display this message
  -v, --version  Display version number
```