### PR TITLE
style: enforce hexadecimal literal casing

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -2,7 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
   "rules": {
     "no-unused-vars": "warn",
-    "no-console": "off"
+    "no-console": "off",
+    "unicorn/number-literal-case": "error"
   },
   "ignorePatterns": ["dist", "node_modules", "src/generated"]
 }

--- a/tests/signing.test.ts
+++ b/tests/signing.test.ts
@@ -63,7 +63,7 @@ describe("verifyBundleSignature (v1 protocol)", () => {
   it("rejects a tampered signature", () => {
     const signature = signCanonical(1, sampleBody);
     const sigBuf = Buffer.from(signature, "base64");
-    sigBuf[0] = sigBuf[0]! ^ 0xff;
+    sigBuf[0] = sigBuf[0]! ^ 0xFF;
     const tamperedSig = sigBuf.toString("base64");
     expect(() => {
       verifyBundleSignatureWithKeyset(sampleBody, tamperedSig, 1, hashHex(sampleBody), testKeyset);

--- a/tests/tool-switch.test.ts
+++ b/tests/tool-switch.test.ts
@@ -302,8 +302,8 @@ describe("migrateArtifacts", () => {
     const toPath = join(tmp, newProfile.skillPath("code-review"));
     mkdirSync(join(fromPath, ".."), { recursive: true });
     mkdirSync(join(toPath, ".."), { recursive: true });
-    writeFileSync(fromPath, Buffer.from([0xff, 0xfe]));
-    writeFileSync(toPath, Buffer.from([0xfe, 0xff]));
+    writeFileSync(fromPath, Buffer.from([0xFF, 0xFE]));
+    writeFileSync(toPath, Buffer.from([0xFE, 0xFF]));
 
     const summary = migrateArtifacts(tmp, orphan, newProfile);
 
@@ -318,9 +318,9 @@ describe("migrateArtifacts", () => {
     );
     // Source was not removed
     expect(existsSync(fromPath)).toBe(true);
-    expect(readFileSync(fromPath).equals(Buffer.from([0xff, 0xfe]))).toBe(true);
+    expect(readFileSync(fromPath).equals(Buffer.from([0xFF, 0xFE]))).toBe(true);
     // Destination untouched
-    expect(readFileSync(toPath).equals(Buffer.from([0xfe, 0xff]))).toBe(true);
+    expect(readFileSync(toPath).equals(Buffer.from([0xFE, 0xFF]))).toBe(true);
   });
 
   it("still treats byte-identical source and destination as a successful no-op move", () => {


### PR DESCRIPTION
## Lint ratchet

Enabled exactly one mechanical rule: `unicorn/number-literal-case`.

## Findings fixed

- 9 lowercase hexadecimal literals normalized to uppercase
- 1 occurrence in `tests/signing.test.ts`
- 8 occurrences in `tests/tool-switch.test.ts`

## Gate

- `bun run typecheck`: pass
- `bun run lint`: 0 errors, exactly 2 protected `no-control-regex` warnings
- `bun test`: 454 pass, exactly 8 pinned failures

No protected control-character sanitization or pinned failing test was changed.